### PR TITLE
Solved bug with TowerSelection while tower placing

### DIFF
--- a/Assets/Scripts/PlacingTower/TowerPlacement.cs
+++ b/Assets/Scripts/PlacingTower/TowerPlacement.cs
@@ -32,6 +32,8 @@ public class TowerPlacement : MonoBehaviour
         // Updating the tower position (and placing it on click)
         if (newTower != null && !isPlaced)
         {
+            // Disable TowerSelection script cause we do not want to select towers while placing one
+            GameObject.Find("GameScripts").GetComponent<TowerSelection>().enabled = false;
 
             RaycastHit hit = new RaycastHit();
             // Ray that goes from the screen (camera) to the mouse position
@@ -47,9 +49,7 @@ public class TowerPlacement : MonoBehaviour
                 numWidth2 = (Screen.width - 400) / 3.14f;
                 // Point of the terrain where we are aiming at
                 Vector3 point = hit.point;
-                // Giving the position to the newTower 
-                // (height to 0 to place it on the "terrain height 0" and not on the "mountains")
-                // (where we put towers is supposed to be a flat terrain of height 0)
+                // Giving the position to the newTower (using the height of the object itself for y axis and mouse  for x and z axis)
                 newTower.transform.position = new Vector3(point.x, newTower.position.y, point.z);
                 // Cancell the tower placement by using right click and the Tower is not placed if clicking over the HUD
                 if (Input.GetMouseButtonDown(1) || (Input.GetMouseButtonDown(0) && Input.mousePosition.y < (54 + numHeight)
@@ -81,7 +81,6 @@ public class TowerPlacement : MonoBehaviour
                     
 					LogicConnector.decreaseCredit(towerCost);
 
-
                 }
             }
 
@@ -89,6 +88,9 @@ public class TowerPlacement : MonoBehaviour
         else
         {
             // already placed (or null)
+
+            // Re enable TowerSelection script
+            GameObject.Find("GameScripts").GetComponent<TowerSelection>().enabled = true;
         }
     }
 

--- a/Assets/Scripts/PlacingTower/TowerSelection.cs
+++ b/Assets/Scripts/PlacingTower/TowerSelection.cs
@@ -47,67 +47,33 @@ public class TowerSelection : MonoBehaviour
                 Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
                 if (Physics.Raycast(ray, out hit, Mathf.Infinity))
                 {
-                    if (hit.transform.tag == "Button")
+                    // If we already have a tower selected, reset the color and unselect it
+                    if (tower != null)
                     {
-
+                        // set back the initial renderer color of the tower
+                        tower.GetComponent<Renderer>().material.color = colorInicial;
+                        // unselect the tower
+                        tower = null;
                     }
-                    // Check if we clicked a tower
+
+                    // Check if we clicked a tower: select a new one and draw the buttons from OnGUI
                     if (hit.transform.gameObject.tag == "tower")
                     {
-                        // If we already have a tower selected, unselect it and reset the color
-                        if (tower != null)
-                        {
-                            // set back the initial renderer color of the tower (if it is not a new tower)
-                            if (!newTower)
-                            {
-                                tower.GetComponent<Renderer>().material.color = colorInicial;
-                            }
-                            // unselect the tower
-                            tower = null;
-                        }
-
                         // get the new selection
                         tower = hit.transform.gameObject;
+                        // store the initial color
+                        colorInicial = tower.GetComponent<Renderer>().material.color;
+                        // set blue color for a selected tower
+                        tower.GetComponent<Renderer>().material.color = new Color32(0, 0, 255, 125);
 
-                        // If we are selecting a tower we are placing (new tower) do not select it
-                        if (tower.GetComponent<Renderer>().material.color == new Color32(0, 255, 0, 125) ||
-                            tower.GetComponent<Renderer>().material.color == new Color32(255, 0, 0, 125))
-                        {
-                            tower = null;
-
-                            // set boolean values
-                            this.showSelected = false;
-                            newTower = true;
-                        }
-                        // Selecting a tower we have already placed
-                        else
-                        {
-                            // store the initial color
-                            colorInicial = tower.GetComponent<Renderer>().material.color;
-                            // set blue color for a selected tower
-                            tower.GetComponent<Renderer>().material.color = new Color32(0, 0, 255, 125);
-
-                            // set boolean values
-                            this.showSelected = true;
-                            newTower = false;
-                        }
+                        // means OnGUI method will draw the buttons and evaluate the click on them
+                        this.showSelected = true;
                     }
-                    // If not, unselect the tower
+                    // If not, clear the buttons from OnGUI
                     else
                     {
-                        if (tower != null)
-                        {
-                            // set back the initial renderer color of the tower (if it is not a new tower)
-                            if (!newTower)
-                            {
-                                tower.GetComponent<Renderer>().material.color = colorInicial;
-                            }
-                            // unselect the tower
-                            tower = null;
-                        }
-                        // set boolean values
+                        // means OnGUI method will do nothing 
                         this.showSelected = false;
-                        newTower = false;
                     }
                 }
             }


### PR DESCRIPTION
Solved the bug explained here [https://github.com/NestorTejero/ES2016A/issues/158](https://github.com/NestorTejero/ES2016A/issues/158)

Now you will not select towers while placing a tower. TowerPlacement enables/disables the TowerSelection script when tower placing. This way the code from TowerSelection gets more clean (it does not need to check that we are placing a tower when we click).