### PR TITLE
Tower xml stats, 3 tower levels

### DIFF
--- a/Assets/Resources/xml/towers.xml
+++ b/Assets/Resources/xml/towers.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TowerCollection>
+	<Towers>
+	
+		<Tower id="torre-piedra">
+			<Level id="1">
+				<range>20</range>
+				<health>100.0</health>
+				<cost>100</cost>
+				<damage>6</damage>
+				<firerate>1.0</firerate>
+				<turnspeed>2.0</turnspeed>
+			</Level>
+			<Level id="2">
+				<range>30</range>
+				<health>100.0</health>
+				<cost>50</cost>
+				<damage>6</damage>
+				<firerate>0.5</firerate>
+				<turnspeed>2.0</turnspeed>
+			</Level>
+			<Level id="3">
+				<range>40</range>
+				<health>100.0</health>
+				<cost>150</cost>
+				<damage>12</damage>
+				<firerate>0.5</firerate>
+				<turnspeed>4.0</turnspeed>
+			</Level>
+		</Tower>
+
+		<Tower id="torre-tanque">
+			<Level id="1">
+				<range>45</range>
+				<health>100.0</health>
+				<cost>500</cost>
+				<damage>12</damage>
+				<firerate>2.0</firerate>
+				<turnspeed>1.0</turnspeed>
+			</Level>
+			<Level id="2">
+				<range>75</range>
+				<health>100.0</health>
+				<cost>250</cost>
+				<damage>12</damage>
+				<firerate>1.5</firerate>
+				<turnspeed>2.0</turnspeed>
+			</Level>
+			<Level id="3">
+				<range>75</range>
+				<health>100.0</health>
+				<cost>750</cost>
+				<damage>24</damage>
+				<firerate>1.5</firerate>
+				<turnspeed>2.0</turnspeed>
+			</Level>
+		</Tower>
+
+		<Tower id="torre-avion">
+			<Level id="1">
+				<range>40</range>
+				<health>100.0</health>
+				<cost>1000</cost>
+				<damage>2</damage>
+				<firerate>0.33</firerate>
+				<turnspeed>2.0</turnspeed>
+			</Level>
+			<Level id="2">
+				<range>50</range>
+				<health>100.0</health>
+				<cost>500</cost>
+				<damage>5</damage>
+				<firerate>0.33</firerate>
+				<turnspeed>3.0</turnspeed>
+			</Level>
+			<Level id="3">
+				<range>50</range>
+				<health>100.0</health>
+				<cost>1500</cost>
+				<damage>10</damage>
+				<firerate>0.33</firerate>
+				<turnspeed>3.0</turnspeed>
+			</Level>
+		</Tower>
+
+		
+	</Towers>
+</TowerCollection>
+		

--- a/Assets/Resources/xml/towers.xml.meta
+++ b/Assets/Resources/xml/towers.xml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8c349e1fdb52b2e46ad95c0d48996ff6
+timeCreated: 1481321094
+licenseType: Free
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Pull request para finalizar el **issue #163** 

Se ha creado el fichero xml donde se guardan los stats (rango, velocidad de disparo, daño...) de las tres torres. Además se han añadido 2 niveles para cada torre (contando el nivel inicial se tiene un total de 3 niveles por torre). Esto servirá posteriormente para hacer los upgrades de las torres.