### PR TITLE
Dev issue220 - Fix difficulty selection bugs

### DIFF
--- a/Assets/Scenes/menuScene.unity
+++ b/Assets/Scenes/menuScene.unity
@@ -143,7 +143,7 @@ Transform:
   m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.109381676, w: 0.87542605}
   m_LocalPosition: {x: 78, y: 1, z: -134}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -1103,6 +1103,79 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 519521163}
+--- !u!1 &528399525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 528399526}
+  - 222: {fileID: 528399528}
+  - 114: {fileID: 528399527}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &528399526
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 528399525}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 585984776}
+  - {fileID: 924328346}
+  - {fileID: 1536187497}
+  - {fileID: 1780224607}
+  - {fileID: 952227561}
+  m_Father: {fileID: 796990016}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1, y: 0}
+  m_SizeDelta: {x: 457, y: 242}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &528399527
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 528399525}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.071805276, g: 0.328135, b: 0.35294116, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &528399528
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 528399525}
 --- !u!1 &536537423
 GameObject:
   m_ObjectHideFlags: 0
@@ -1196,6 +1269,80 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &585984775
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 585984776}
+  - 222: {fileID: 585984778}
+  - 114: {fileID: 585984777}
+  m_Layer: 5
+  m_Name: Text(Settings)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &585984776
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 585984775}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 528399526}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 11.02301, y: 72.395996}
+  m_SizeDelta: {x: 266, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &585984777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 585984775}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.6156863, g: 0.7647059, b: 0.13333334, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 5fd6659faacca4238ad8e26986a7ffbf, type: 3}
+    m_FontSize: 60
+    m_FontStyle: 2
+    m_BestFit: 0
+    m_MinSize: 6
+    m_MaxSize: 60
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: SELECT DIFFICULTY...
+--- !u!222 &585984778
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 585984775}
 --- !u!1 &672878688
 GameObject:
   m_ObjectHideFlags: 0
@@ -1392,6 +1539,75 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 679500701}
+--- !u!1 &796990015
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 796990016}
+  - 222: {fileID: 796990018}
+  - 114: {fileID: 796990017}
+  m_Layer: 5
+  m_Name: Image(menu)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &796990016
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 796990015}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 528399526}
+  m_Father: {fileID: 1659813229}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0.42872342, y: 0.4358701}
+  m_AnchorMax: {x: 0.5787422, y: 0.58447427}
+  m_AnchoredPosition: {x: 9, y: -19}
+  m_SizeDelta: {x: 362, y: 167}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &796990017
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 796990015}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.6164181, g: 0.7647059, b: 0.13448277, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &796990018
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 796990015}
 --- !u!1 &884317359
 GameObject:
   m_ObjectHideFlags: 0
@@ -1601,6 +1817,128 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 904058545}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &924328345
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 924328346}
+  - 222: {fileID: 924328349}
+  - 114: {fileID: 924328348}
+  - 114: {fileID: 924328347}
+  m_Layer: 5
+  m_Name: VolverSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &924328346
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 924328345}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 528399526}
+  m_RootOrder: 1
+  m_AnchorMin: {x: 0.39764085, y: 0.38548043}
+  m_AnchorMax: {x: 0.5968803, y: 0.6041299}
+  m_AnchoredPosition: {x: -95, y: -99.99997}
+  m_SizeDelta: {x: 97.211334, y: -16.81031}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &924328347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 924328345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 21300000, guid: b22eb2f8bdabf5a4c8171414a9fb2d54,
+      type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 4886f60308bc48b4891595f211088f9b, type: 3}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 924328348}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1552371190}
+        m_MethodName: NoPress
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &924328348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 924328345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 860b67a762625284fad488a88c4222d1, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &924328349
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 924328345}
 --- !u!1 &927666156
 GameObject:
   m_ObjectHideFlags: 0
@@ -1825,12 +2163,12 @@ RectTransform:
   m_LocalScale: {x: 0.36133924, y: 0.51189065, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 1532311199}
+  m_Father: {fileID: 528399526}
   m_RootOrder: 4
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 36.380066, y: -97.1}
-  m_SizeDelta: {x: -12.270813, y: -44.958225}
+  m_AnchoredPosition: {x: 27.488708, y: -86.3243}
+  m_SizeDelta: {x: 90.37793, y: 37.03535}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &952227562
 MonoBehaviour:
@@ -2710,128 +3048,6 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
---- !u!1 &1531020834
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
-  m_Component:
-  - 224: {fileID: 1531020835}
-  - 222: {fileID: 1531020838}
-  - 114: {fileID: 1531020837}
-  - 114: {fileID: 1531020836}
-  m_Layer: 5
-  m_Name: ImageLevel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1531020835
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1531020834}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.8844536, y: 0.63176185, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_Children: []
-  m_Father: {fileID: 1532311199}
-  m_RootOrder: 1
-  m_AnchorMin: {x: 0.39764085, y: 0.38548043}
-  m_AnchorMax: {x: 0.5968803, y: 0.6041299}
-  m_AnchoredPosition: {x: -79, y: -48}
-  m_SizeDelta: {x: -105, y: -65}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1531020836
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1531020834}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 2
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 243565ed3ef5cef4198f3c226880be4b,
-      type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: 243565ed3ef5cef4198f3c226880be4b, type: 3}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 1531020837}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1552371190}
-        m_MethodName: Level
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
---- !u!114 &1531020837
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1531020834}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: 64fdbd6893c04f647a336454eec1353f, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &1531020838
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1531020834}
 --- !u!1 &1532311195
 GameObject:
   m_ObjectHideFlags: 0
@@ -2918,10 +3134,6 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 55228400}
-  - {fileID: 1531020835}
-  - {fileID: 1536187497}
-  - {fileID: 1780224607}
-  - {fileID: 952227561}
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_AnchorMin: {x: 0, y: 0}
@@ -2958,12 +3170,12 @@ RectTransform:
   m_LocalScale: {x: 0.36133924, y: 0.51189065, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 1532311199}
+  m_Father: {fileID: 528399526}
   m_RootOrder: 2
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 36.4, y: -2.8}
-  m_SizeDelta: {x: -12.270813, y: -44.958225}
+  m_AnchoredPosition: {x: 27.508705, y: 7.975726}
+  m_SizeDelta: {x: 90.37793, y: 37.03535}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1536187498
 MonoBehaviour:
@@ -3162,10 +3374,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   quitMenu: {fileID: 536537426}
   MenuConfiguration: {fileID: 1532311198}
+  MenuDiff: {fileID: 1659813228}
   startText: {fileID: 271845203}
   endText: {fileID: 1769930120}
   ButtonMute: {fileID: 1509182356}
-  ButtonLevel: {fileID: 1531020836}
   configurationText: {fileID: 2019634035}
   ImageYes: {fileID: 988773730}
   ImageNo: {fileID: 140136499}
@@ -3265,6 +3477,99 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!1 &1659813225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 1659813229}
+  - 223: {fileID: 1659813228}
+  - 114: {fileID: 1659813227}
+  - 114: {fileID: 1659813226}
+  m_Layer: 5
+  m_Name: MenuDiff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1659813226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1659813225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1659813227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1659813225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &1659813228
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1659813225}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 1
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1659813229
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1659813225}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 796990016}
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &1677703895
 GameObject:
   m_ObjectHideFlags: 0
@@ -3558,12 +3863,12 @@ RectTransform:
   m_LocalScale: {x: 0.36133924, y: 0.51189065, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 1532311199}
+  m_Father: {fileID: 528399526}
   m_RootOrder: 3
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 36.380066, y: -49.6}
-  m_SizeDelta: {x: -12.270813, y: -44.958225}
+  m_AnchoredPosition: {x: 27.488708, y: -38.824303}
+  m_SizeDelta: {x: 90.37793, y: 37.03535}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1780224608
 MonoBehaviour:

--- a/Assets/Scenes/menuScene.unity
+++ b/Assets/Scenes/menuScene.unity
@@ -1821,7 +1821,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 952227560}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1.4}
   m_LocalScale: {x: 0.36133924, y: 0.51189065, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
@@ -1829,7 +1829,7 @@ RectTransform:
   m_RootOrder: 4
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 36.380066, y: -85.6}
+  m_AnchoredPosition: {x: 36.380066, y: -97.1}
   m_SizeDelta: {x: -12.270813, y: -44.958225}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &952227562
@@ -2962,7 +2962,7 @@ RectTransform:
   m_RootOrder: 2
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 36.380066, y: -14.9}
+  m_AnchoredPosition: {x: 36.4, y: -2.8}
   m_SizeDelta: {x: -12.270813, y: -44.958225}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1536187498

--- a/Assets/Scenes/menuScene.unity
+++ b/Assets/Scenes/menuScene.unity
@@ -143,6 +143,7 @@ Transform:
   m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.109381676, w: 0.87542605}
   m_LocalPosition: {x: 78, y: 1, z: -134}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -172,6 +173,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 194039762}
   m_Father: {fileID: 1532311199}
@@ -241,6 +243,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 194039762}
   m_RootOrder: 2
@@ -361,6 +364,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 194039762}
   m_RootOrder: 3
@@ -538,6 +542,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -567,6 +572,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 988773728}
   - {fileID: 1418109139}
@@ -640,6 +646,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 968664809}
   m_Father: {fileID: 2042873336}
@@ -714,6 +721,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 519521164}
   m_Father: {fileID: 536537427}
@@ -823,6 +831,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -853,6 +862,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1915077759}
   m_RootOrder: 5
@@ -972,6 +982,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1891995201}
   m_RootOrder: 0
@@ -1045,6 +1056,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1805842106}
   - {fileID: 947349466}
@@ -1161,6 +1173,7 @@ Canvas:
   m_ReceivesEvents: 1
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -1173,6 +1186,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 215220311}
   m_Father: {fileID: 0}
@@ -1209,6 +1223,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1163107660}
   m_Father: {fileID: 1552371189}
@@ -1329,6 +1344,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 194039762}
   m_RootOrder: 5
@@ -1403,6 +1419,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 519521164}
   m_RootOrder: 3
@@ -1524,6 +1541,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -622, y: -333, z: 187}
   m_LocalScale: {x: 1368.0397, y: 540.89325, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1915077759}
   m_RootOrder: 1
@@ -1609,6 +1627,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1163107660}
   m_RootOrder: 0
@@ -1683,6 +1702,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 519521164}
   m_RootOrder: 1
@@ -1803,6 +1823,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.36133924, y: 0.51189065, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1532311199}
   m_RootOrder: 4
@@ -1839,7 +1860,7 @@ MonoBehaviour:
   m_SpriteState:
     m_HighlightedSprite: {fileID: 21300000, guid: a85b4fe6e72aec743b12b1611b4cdbf6,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: 2a6046b391721494c8a566311f19dfc3, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: a5ea41a8264aa6943986177018586144, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -1883,7 +1904,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: a85b4fe6e72aec743b12b1611b4cdbf6, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 6c53c9c157cb07b4582d29be5cd8d3e9, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1923,6 +1944,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 2, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1915077759}
   m_RootOrder: 2
@@ -1990,6 +2012,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 208423870}
   m_RootOrder: 0
@@ -2064,6 +2087,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 194039762}
   m_RootOrder: 0
@@ -2183,6 +2207,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 519521164}
   m_RootOrder: 2
@@ -2250,6 +2275,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 927666157}
   m_Father: {fileID: 672878689}
@@ -2324,6 +2350,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 194039762}
   m_RootOrder: 1
@@ -2392,6 +2419,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1677703896}
   m_Father: {fileID: 1552371189}
@@ -2512,6 +2540,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 519521164}
   m_RootOrder: 4
@@ -2586,6 +2615,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 194039762}
   m_RootOrder: 4
@@ -2707,6 +2737,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.8844536, y: 0.63176185, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1532311199}
   m_RootOrder: 1
@@ -2787,7 +2818,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: 243565ed3ef5cef4198f3c226880be4b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 64fdbd6893c04f647a336454eec1353f, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2871,6 +2902,7 @@ Canvas:
   m_ReceivesEvents: 1
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -2883,6 +2915,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 55228400}
   - {fileID: 1531020835}
@@ -2923,6 +2956,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.36133924, y: 0.51189065, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1532311199}
   m_RootOrder: 2
@@ -2959,7 +2993,7 @@ MonoBehaviour:
   m_SpriteState:
     m_HighlightedSprite: {fileID: 21300000, guid: cc37c96eee7cf014e8fcffdcbf39324e,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: 6abf62aceea64964ea4f9e8785a01343, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 8bb996ec05498bc49b5bdd13b426a274, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -3003,7 +3037,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: cc37c96eee7cf014e8fcffdcbf39324e, type: 3}
+  m_Sprite: {fileID: 21300000, guid: e6b467f16770af841b13fb72cb211fe4, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3089,6 +3123,7 @@ Canvas:
   m_ReceivesEvents: 1
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -3101,6 +3136,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1915077759}
   - {fileID: 672878689}
@@ -3255,6 +3291,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 2076135465}
   m_Father: {fileID: 1465123968}
@@ -3329,6 +3366,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1915077759}
   m_RootOrder: 0
@@ -3397,6 +3435,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1915077759}
   m_RootOrder: 3
@@ -3517,6 +3556,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.36133924, y: 0.51189065, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1532311199}
   m_RootOrder: 3
@@ -3553,7 +3593,7 @@ MonoBehaviour:
   m_SpriteState:
     m_HighlightedSprite: {fileID: 21300000, guid: ba205ba397102114d8c49cf177b687aa,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: fd3c6889c5567124cb1cc00c42344c24, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 1b41b6a93ab215c4bb2b87a6fa507a83, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -3597,7 +3637,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: ba205ba397102114d8c49cf177b687aa, type: 3}
+  m_Sprite: {fileID: 21300000, guid: f7f720cb8e0e7a64e9bd572872052759, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3637,6 +3677,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 519521164}
   m_RootOrder: 0
@@ -3736,6 +3777,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -3765,6 +3807,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 508607280}
   m_Father: {fileID: 1915077759}
@@ -3839,6 +3882,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1768155421}
   - {fileID: 904058546}
@@ -3914,6 +3958,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1915077759}
   m_RootOrder: 4
@@ -4034,6 +4079,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 208423870}
   m_Father: {fileID: 1552371189}
@@ -4154,6 +4200,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1677703896}
   m_RootOrder: 0

--- a/Assets/Scenes/menuScene.unity
+++ b/Assets/Scenes/menuScene.unity
@@ -249,7 +249,7 @@ RectTransform:
   m_RootOrder: 2
   m_AnchorMin: {x: 0.39764085, y: 0.40112993}
   m_AnchorMax: {x: 0.5968803, y: 0.6041299}
-  m_AnchoredPosition: {x: 16, y: 6.5}
+  m_AnchoredPosition: {x: 30, y: -27}
   m_SizeDelta: {x: 28.211334, y: -21.333023}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &140136498
@@ -278,8 +278,9 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 21300000, guid: 7acec6c073bb29a418b3827226226e7c, type: 3}
+    m_HighlightedSprite: {fileID: 21300000, guid: 7acec6c073bb29a418b3827226226e7c,
+      type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e4580f2869b64d44293756b0efea6c04, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -361,7 +362,7 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 141132828}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -370,7 +371,7 @@ RectTransform:
   m_RootOrder: 3
   m_AnchorMin: {x: 0.39764085, y: 0.38548043}
   m_AnchorMax: {x: 0.5968803, y: 0.6041299}
-  m_AnchoredPosition: {x: -95, y: -100}
+  m_AnchoredPosition: {x: 4, y: -79}
   m_SizeDelta: {x: 97.211334, y: -16.81031}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &141132830
@@ -1302,7 +1303,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 11.02301, y: 72.395996}
-  m_SizeDelta: {x: 266, y: 60}
+  m_SizeDelta: {x: 280, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &585984777
 MonoBehaviour:
@@ -1325,10 +1326,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: 5fd6659faacca4238ad8e26986a7ffbf, type: 3}
-    m_FontSize: 60
+    m_FontSize: 35
     m_FontStyle: 2
     m_BestFit: 0
-    m_MinSize: 6
+    m_MinSize: 3
     m_MaxSize: 60
     m_Alignment: 3
     m_AlignByGeometry: 0
@@ -1670,8 +1671,9 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 21300000, guid: 53d82b41e3d26cd4b9db69c8aff0217c, type: 3}
+    m_HighlightedSprite: {fileID: 21300000, guid: 53d82b41e3d26cd4b9db69c8aff0217c,
+      type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 703501a20e81270489c2d0d202c4fa78, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -1850,7 +1852,7 @@ RectTransform:
   m_RootOrder: 1
   m_AnchorMin: {x: 0.39764085, y: 0.38548043}
   m_AnchorMax: {x: 0.5968803, y: 0.6041299}
-  m_AnchoredPosition: {x: -95, y: -99.99997}
+  m_AnchoredPosition: {x: 4, y: -79}
   m_SizeDelta: {x: 97.211334, y: -16.81031}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &924328347
@@ -2075,8 +2077,9 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 21300000, guid: 7acec6c073bb29a418b3827226226e7c, type: 3}
+    m_HighlightedSprite: {fileID: 21300000, guid: 7acec6c073bb29a418b3827226226e7c,
+      type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e4580f2869b64d44293756b0efea6c04, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -2167,8 +2170,8 @@ RectTransform:
   m_RootOrder: 4
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 27.488708, y: -86.3243}
-  m_SizeDelta: {x: 90.37793, y: 37.03535}
+  m_AnchoredPosition: {x: 99, y: -9.999999}
+  m_SizeDelta: {x: 90.37793, y: 36}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &952227562
 MonoBehaviour:
@@ -2196,7 +2199,7 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: a85b4fe6e72aec743b12b1611b4cdbf6,
+    m_HighlightedSprite: {fileID: 21300000, guid: a5ea41a8264aa6943986177018586144,
       type: 3}
     m_PressedSprite: {fileID: 21300000, guid: a5ea41a8264aa6943986177018586144, type: 3}
     m_DisabledSprite: {fileID: 0}
@@ -2431,7 +2434,7 @@ RectTransform:
   m_RootOrder: 0
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 27, y: 39.7}
+  m_AnchoredPosition: {x: 44, y: 17}
   m_SizeDelta: {x: 28.788696, y: -26.81031}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &988773729
@@ -2460,8 +2463,9 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 21300000, guid: 53d82b41e3d26cd4b9db69c8aff0217c, type: 3}
+    m_HighlightedSprite: {fileID: 21300000, guid: 53d82b41e3d26cd4b9db69c8aff0217c,
+      type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 703501a20e81270489c2d0d202c4fa78, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -2959,7 +2963,7 @@ RectTransform:
   m_RootOrder: 4
   m_AnchorMin: {x: 0.39764085, y: 0.38548043}
   m_AnchorMax: {x: 0.5968803, y: 0.6041299}
-  m_AnchoredPosition: {x: -111, y: 19}
+  m_AnchoredPosition: {x: -111, y: -9}
   m_SizeDelta: {x: 49.211334, y: -1.8103104}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1509182354
@@ -3174,8 +3178,8 @@ RectTransform:
   m_RootOrder: 2
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 27.508705, y: 7.975726}
-  m_SizeDelta: {x: 90.37793, y: 37.03535}
+  m_AnchoredPosition: {x: -91, y: -10}
+  m_SizeDelta: {x: 90.37793, y: 36}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1536187498
 MonoBehaviour:
@@ -3203,7 +3207,7 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: cc37c96eee7cf014e8fcffdcbf39324e,
+    m_HighlightedSprite: {fileID: 21300000, guid: 8bb996ec05498bc49b5bdd13b426a274,
       type: 3}
     m_PressedSprite: {fileID: 21300000, guid: 8bb996ec05498bc49b5bdd13b426a274, type: 3}
     m_DisabledSprite: {fileID: 0}
@@ -3379,6 +3383,9 @@ MonoBehaviour:
   endText: {fileID: 1769930120}
   ButtonMute: {fileID: 1509182356}
   configurationText: {fileID: 2019634035}
+  Play: {fileID: 672878690}
+  Settings: {fileID: 1465123969}
+  Exit: {fileID: 2042873337}
   ImageYes: {fileID: 988773730}
   ImageNo: {fileID: 140136499}
   ImageLevelEasy: {fileID: 1536187499}
@@ -3867,8 +3874,8 @@ RectTransform:
   m_RootOrder: 3
   m_AnchorMin: {x: 0.4065986, y: 0.38548043}
   m_AnchorMax: {x: 0.60400003, y: 0.6041299}
-  m_AnchoredPosition: {x: 27.488708, y: -38.824303}
-  m_SizeDelta: {x: 90.37793, y: 37.03535}
+  m_AnchoredPosition: {x: -6, y: -9.999999}
+  m_SizeDelta: {x: 90.37793, y: 36}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1780224608
 MonoBehaviour:
@@ -3896,7 +3903,7 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: ba205ba397102114d8c49cf177b687aa,
+    m_HighlightedSprite: {fileID: 21300000, guid: 1b41b6a93ab215c4bb2b87a6fa507a83,
       type: 3}
     m_PressedSprite: {fileID: 21300000, guid: 1b41b6a93ab215c4bb2b87a6fa507a83, type: 3}
     m_DisabledSprite: {fileID: 0}

--- a/Assets/Scripts/GameGUI/LogicConnector.cs
+++ b/Assets/Scripts/GameGUI/LogicConnector.cs
@@ -37,7 +37,7 @@ public class LogicConnector {
     public enum Difficulty { Easy, Medium, Hard };
     [Header("Game Difficulty")]
     public Difficulty Difficult = LogicConnector.Difficulty.Easy;
-    private String difficulty;
+    private String difficulty = LogicConnector.Difficulty.Easy.ToString();
 
     // Variables de la logica.
     [Header("Game logic values")]

--- a/Assets/Scripts/menusScript.cs
+++ b/Assets/Scripts/menusScript.cs
@@ -7,12 +7,15 @@ public class menusScript : MonoBehaviour {
 
     public Canvas quitMenu;
     public Canvas MenuConfiguration;
+    public Canvas MenuDiff;
     public Button startText;
     public Button endText;
     public Button ButtonMute;
-    public Button ButtonLevel;
     public Button configurationText;
-
+    public Button Play;
+    public Button Settings;
+    public Button Exit;
+    
     public Image ImageYes;
     public Image ImageNo;
     public Image ImageLevelEasy;
@@ -29,8 +32,11 @@ public class menusScript : MonoBehaviour {
     void Start () {
         quitMenu = quitMenu.GetComponent<Canvas>();
         MenuConfiguration = MenuConfiguration.GetComponent<Canvas>();
+        MenuDiff = MenuDiff.GetComponent<Canvas>();
         ButtonMute = ButtonMute.GetComponent<Button>();
-        ButtonLevel = ButtonLevel.GetComponent<Button>();
+        Play = Play.GetComponent<Button>();
+        Settings = Settings.GetComponent<Button>();
+        Exit = Exit.GetComponent<Button>();
 
         ImageYes = ImageYes.GetComponent<Image>();
         ImageNo = ImageNo.GetComponent<Image>();
@@ -43,6 +49,7 @@ public class menusScript : MonoBehaviour {
         configurationText = configurationText.GetComponent<Button>();
         quitMenu.enabled = false;
         MenuConfiguration.enabled = false;
+        MenuDiff.enabled = false;
         PlayAudio();
     }
 
@@ -60,6 +67,9 @@ public class menusScript : MonoBehaviour {
 		configurationText.enabled = false;
         startText.enabled = false;
         endText.enabled = false;
+        Play.enabled = false;
+        Settings.enabled = false;
+        Exit.enabled = false;
     }
 
     public void MenuConfig()
@@ -68,12 +78,13 @@ public class menusScript : MonoBehaviour {
 
         ImageYes.enabled = false;
         ImageNo.enabled = false;
-        ImageLevelEasy.enabled = false;
-        ImageLevelMedium.enabled = false;
-        ImageLevelHard.enabled = false;
 
         startText.enabled = false;
         endText.enabled = false;
+
+        Play.enabled = false;
+        Settings.enabled = false;
+        Exit.enabled = false;
     }
 
     public void Mute()
@@ -115,27 +126,21 @@ public class menusScript : MonoBehaviour {
     {
         var instance =LogicConnector.getInstance();
         instance.Difficult = LogicConnector.Difficulty.Easy;
-        ImageLevelEasy.enabled = false;
-        ImageLevelMedium.enabled = false;
-        ImageLevelHard.enabled = false;
+        SceneManager.LoadScene("Game");
     }
 
     public void SetLevelMedium()
     {
         var instance = LogicConnector.getInstance();
         instance.Difficult = LogicConnector.Difficulty.Medium;
-        ImageLevelEasy.enabled = false;
-        ImageLevelMedium.enabled = false;
-        ImageLevelHard.enabled = false;
+        SceneManager.LoadScene("Game");
     }
 
     public void SetLevelHard()
     {
         var instance = LogicConnector.getInstance();
         instance.Difficult = LogicConnector.Difficulty.Hard;
-        ImageLevelEasy.enabled = false;
-        ImageLevelMedium.enabled = false;
-        ImageLevelHard.enabled = false;
+        SceneManager.LoadScene("Game");
     }
 
     public void MuteSound()
@@ -165,10 +170,22 @@ public class menusScript : MonoBehaviour {
             MenuConfiguration.enabled = false;
         }
 
+        if (MenuDiff.enabled==true)
+        {
+            MenuDiff.enabled = false;
+        }
+
 		configurationText.enabled = true;
 
         startText.enabled = true;
         endText.enabled = true;
+        Play.enabled = true;
+        Settings.enabled = true;
+        Exit.enabled = true;
+        ImageLevelEasy.enabled = false;
+        ImageLevelMedium.enabled = false;
+        ImageLevelHard.enabled = false;
+
     }
 
     public void UnMute()
@@ -192,7 +209,13 @@ public class menusScript : MonoBehaviour {
     public void startLevel() {
         // Scene sc=SceneManager.GetActiveScene();
         // int numSceneActive = sc.buildIndex;
-		SceneManager.LoadScene("Game");
+        ImageLevelEasy.enabled = true;
+        ImageLevelMedium.enabled = true;
+        ImageLevelHard.enabled = true;
+        MenuDiff.enabled = true;
+        Play.enabled = false;
+        Settings.enabled = false;
+        Exit.enabled = false;
     }
 
     public void exitGame() {


### PR DESCRIPTION
Estado actual de la Issue #220 :

- El juego empieza aunque no se seleccione ninguna dificultad. La dificultad por defecto es EASY.
- La dificultad puede cambiarse desde el menú principal. Una vez elegida la dificultad, esta se mantendrá igual en todas las partidas hasta que vuelva a cambiarse o se cierre el programa.
- Los botones para elegir dificultad muestran una textura que explicita qué dificultad se está eligiendo (ya no son bloques en blanco).
- El estilo de los botones para elegir dificultad muy distinto al del resto del menú. No supone un problema para la jugabilidad, pero si alguien quiere cambiarlo para mejorar la user's experience puede hacer un commit a esta rama antes del merge.
- He notado que los botones son un poco problemáticos para elegir el nivel de dificultad: depende del lugar donde pulses el botón puede que la lógica del juego tome la dificultad asignada a otro botón. He intentado mitigar este efecto desplazando un poco los botones pero el problema persiste. Para el siguiente sprint recomiendo substituir este sistema por una slide.