### PR TITLE
Logic for Columbus tower's appearance changing when damaged

### DIFF
--- a/Assets/Scripts/HomeBehavior.cs
+++ b/Assets/Scripts/HomeBehavior.cs
@@ -42,7 +42,7 @@ public class HomeBehavior : MonoBehaviour {
             if (ThesholdIsReached() && thresholdMeshes.Length != 0)
             {      
                 gameObject.GetComponent<MeshFilter>().mesh = thresholdMeshes[threshold]; // swap mesh
-                threshold = (int)Mathf.Min(threshold + 1, thresholdMeshes.Length - 1);   // update threshold
+                threshold = (int)Mathf.Min(threshold + 1, thresholdMeshes.Length);   // update threshold
             }
         }
     }

--- a/Assets/Scripts/HomeBehavior.cs
+++ b/Assets/Scripts/HomeBehavior.cs
@@ -10,6 +10,10 @@ public class HomeBehavior : MonoBehaviour {
     public float health = 100f;
     public int initCredit = 300;        // Initial ammount of credit
 
+    // Damage thresholds
+    private int threshold = 0;          // current threshold
+    public Mesh[] thresholdMeshes;            // threshold meshes          
+
     // Collision management.
     void OnTriggerEnter(Collider other)
     {
@@ -30,27 +34,45 @@ public class HomeBehavior : MonoBehaviour {
 
         if (health == 0)
         {
-
-            LogicConnector.setHealth(0);
-
-            LogicConnector.setRound(score.getRound());
-            LogicConnector.setEnemies(score.getEnemies());
-            LogicConnector.setTowersBuilt(score.getTowersBuilt());
-            LogicConnector.setTowersSold(score.getTowersSold());
-            LogicConnector.setGoldEarned(score.getGoldEarned());
-            LogicConnector.setTotalTime(score.getTime());
-            LogicConnector.setScore(score.getScore());
-            LogicConnector.setWin(false);
-
-            LogicConnector.GameOver();
             SelfDestroy();
+        }
+        else
+        {
+            // Change mesh if threshold has been reached:
+            if (ThesholdIsReached() && thresholdMeshes.Length != 0)
+            {      
+                gameObject.GetComponent<MeshFilter>().mesh = thresholdMeshes[threshold]; // swap mesh
+                threshold = (int)Mathf.Min(threshold + 1, thresholdMeshes.Length - 1);   // update threshold
+            }
         }
     }
 
     // Can be modified to add cool effects when the entity is destroyed.
     protected virtual void SelfDestroy()
     {
+        Destroy(gameObject);    
+        GameOver();
+    }
 
-        Destroy(gameObject);
+    private bool ThesholdIsReached()
+    {
+        int n = thresholdMeshes.Length;     // number of reachable thresholds
+        return health <= (maxHealth * (n - threshold) / (n + 1));
+    }
+
+    private void GameOver()
+    {
+        LogicConnector.setHealth(0);
+
+        LogicConnector.setRound(score.getRound());
+        LogicConnector.setEnemies(score.getEnemies());
+        LogicConnector.setTowersBuilt(score.getTowersBuilt());
+        LogicConnector.setTowersSold(score.getTowersSold());
+        LogicConnector.setGoldEarned(score.getGoldEarned());
+        LogicConnector.setTotalTime(score.getTime());
+        LogicConnector.setScore(score.getScore());
+        LogicConnector.setWin(false);
+
+        LogicConnector.GameOver();
     }
 }


### PR DESCRIPTION
See issue #172 for implementation details.

Basically, the redefined HomeBehavior allows for N meshes to be assigned to the prefab through the Inspector (variable named threshold Meshes). The script then defines N damage thesholds, and changes home's mesh once a threshold is reached. I've decided to work with meshes rather than objects because it's much more simplier provided all the meshes are about the same size. 
Changing the mesh does not change the material. If that proves to be a problem, material can be changed just as easily as mesh.

**Recommendations for testing:**
- Columbus tower's mesh is much more bigger than most game meshes. Since Home's scale keeps the same after changing the mesh, some meshes might look very tiny when placed.  I recommend using Unity native meshes (Cube, Sphere, etc...), those look small but visible.
- I also recommend to lower both health and MAXIMUM HEALTH, to about 10N being N the number of meshes.