### PR TITLE
Dev issue244 - New towers can be rotated while being placed

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -392,11 +392,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a5b16a3f6d2303c4a9400f49d6eaa15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveSpeed: 250
+  moveSpeed: 50
   scrollSpeed: 250
   minimumBoundary: {x: 10, y: 20, z: -10}
   maximumBoundary: {x: 190, y: 80, z: 120}
   targetTag: home
+  zoomEnabled: 1
 --- !u!81 &136881509
 AudioListener:
   m_ObjectHideFlags: 0
@@ -461,7 +462,7 @@ Transform:
   m_LocalRotation: {x: 0.38268346, y: 0, z: 0, w: 0.9238795}
   m_LocalPosition: {x: 105, y: 50, z: 50}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 7
@@ -15523,7 +15524,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: dfd47a377468c7f41a07a50d605f5436, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.2096774
   m_Pitch: 1
   Loop: 0
   Mute: 1

--- a/Assets/Scripts/CameraMovement.cs
+++ b/Assets/Scripts/CameraMovement.cs
@@ -4,7 +4,7 @@ using System.Collections;
 public class CameraMovement : MonoBehaviour
 {
 
-    public float moveSpeed = 250f;      // movement through keyboard arrows
+    public float moveSpeed = 50f;       // movement through keyboard arrows
     public float scrollSpeed = 250f;    // movement through mouse wheel
 
     // Camera boundaries. User cannot place camera outside the space defined by this coordinates
@@ -13,6 +13,7 @@ public class CameraMovement : MonoBehaviour
     // X,Z boundaries should be related to the size of the terrain. Altitude optimal boundary (Y) has to be tested.
 
     public string targetTag = "home";
+    public bool zoomEnabled = true;   // zoom (scroll) enabled
 
     void Start()
     {
@@ -41,8 +42,10 @@ public class CameraMovement : MonoBehaviour
         {
             MoveCamera(new Vector3(0, 0, moveSpeed * Time.deltaTime));
         }
+        if (!zoomEnabled)    // end if zoom is not enabled
+            return;
 
-        // Check for mouse wheel
+        // Zoom: check for mouse wheel 
         float scroll = Input.GetAxis("Mouse ScrollWheel");
         if (scroll != 0)
         {

--- a/Assets/Scripts/PlacingTower/TowerPlacement.cs
+++ b/Assets/Scripts/PlacingTower/TowerPlacement.cs
@@ -18,6 +18,7 @@ public class TowerPlacement : MonoBehaviour
     public int type_tower; // 0 -> dinosaur / 1 -> tank / 2 -> tower
 
     public Vector3 scale = new Vector3(10,10,10);
+    public float scrollSpeed = 250f;       // tower placement rotation
 
 
     // Use this for initialization
@@ -33,8 +34,18 @@ public class TowerPlacement : MonoBehaviour
         // Updating the tower position (and placing it on click)
         if (newTower != null && !isPlaced)
         {
+            // Check for mouse wheel. Rotate new tower if scroll
+            float scroll = Input.GetAxis("Mouse ScrollWheel");
+            if (scroll != 0)
+            {
+                // Inversed Y axis
+                newTower.transform.Rotate(new Vector3(0, -scroll * scrollSpeed * 10 * Time.deltaTime, 0));             
+            }
+
             // Disable TowerSelection script cause we do not want to select towers while placing one
             GameObject.Find("GameScripts").GetComponent<TowerSelection>().enabled = false;
+            // Disable Camera zoom, freeing scroll input
+            GameObject.Find("Camera").GetComponent<CameraMovement>().zoomEnabled = false;
 
             RaycastHit hit = new RaycastHit();
             // Ray that goes from the screen (camera) to the mouse position
@@ -96,6 +107,8 @@ public class TowerPlacement : MonoBehaviour
 
             // Re enable TowerSelection script
             GameObject.Find("GameScripts").GetComponent<TowerSelection>().enabled = true;
+            // Re enable Camera zoomt
+            GameObject.Find("Camera").GetComponent<CameraMovement>().zoomEnabled = true;
         }
     }
 


### PR DESCRIPTION
Issue #244 
Scrolling while placing a tower allows to rotate the tower. Camera zoom stays disabled while tower placement occurs.

![image](https://cloud.githubusercontent.com/assets/17719241/21289130/3cd0f3e4-c495-11e6-876a-8530e99b8ac5.png)

I am using inversed Y-axis: tower rotates clockwise when scroll-down. Tell me if tou think it should be the other way. Rotation speed can be manipulated through Inspector, recommended range is [200, 500].