### PR TITLE
Dev issue242 - Fix tower accuracy

### DIFF
--- a/Assets/Resources/Prefabs/projectile-stone.prefab
+++ b/Assets/Resources/Prefabs/projectile-stone.prefab
@@ -81,8 +81,8 @@ MonoBehaviour:
   targetTag: 
   parentTagName: 
   reach: 0
-  gravity: 18
-  upAccel: 4
+  gravity: 5
+  upSpeed: 0
 --- !u!135 &13532580
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/ProjectileBehaviour.cs
+++ b/Assets/Scripts/ProjectileBehaviour.cs
@@ -47,7 +47,7 @@ public class ProjectileBehaviour : MonoBehaviour {
 	
 	// Update is called once per frame
 	void Update () {
-        if (ReachExceeded())
+        if (ReachExceeded() || transform.position.y < 0)
         {
             SelfDestroy();
         }
@@ -108,8 +108,13 @@ public class ProjectileBehaviour : MonoBehaviour {
              *      t = speed / x
              *      v_y = g * (d / v) / 2 - y_0 * (v / d)
              * */
-            float distance = Mathf.Min(reach, (targetPosition - transform.position).magnitude);
-            upSpeed = 0.5f * gravity * (distance / speed) - transform.position.y * (speed / distance);
+            
+            Vector3 currentPosition = transform.position;
+            currentPosition.y = 0;  // ignore vertical components
+            targetPosition.y = 0;
+
+            float distance = (targetPosition - currentPosition).magnitude;
+            upSpeed = Mathf.Abs(0.5f * gravity * (distance / speed) - transform.position.y * (speed / distance)) + 0.004f;
         }
             
     }

--- a/Assets/Scripts/TowerBehavior.cs
+++ b/Assets/Scripts/TowerBehavior.cs
@@ -174,6 +174,7 @@ public class TowerBehavior : MonoBehaviour
 			// Set tags
 			pb.parentTagName = gameObject.tag;
 			pb.targetTag = target.tag;
+            pb.setUpSpeed(target.transform.position);
         }
     }
 

--- a/Assets/Scripts/TowerBehavior.cs
+++ b/Assets/Scripts/TowerBehavior.cs
@@ -135,7 +135,12 @@ public class TowerBehavior : MonoBehaviour
 
 		// Return found target, or null if none in range
 		if (foundTarget != null) {
-			targetSpeed = foundTarget.GetComponent<NavMeshAgent> ().speed;
+            NavMeshAgent agent = foundTarget.GetComponent<NavMeshAgent>(); // target's navigation agent
+            // Check if target is static
+            if (agent.velocity.x == 0 && agent.velocity.z == 0)
+                targetSpeed = 0;            // this assignation avoids computing square rooted vector magnitudes
+            else
+                targetSpeed = agent.speed;  // use speed stat normally if target is not static
 			return foundTarget;
 		}
 		return null;


### PR DESCRIPTION
Issue #242 - 

Las torres ya no fallan los tiros contra enemigos estáticos.

Los proyectiles de la torre de piedra (catapulta) no tenían velocidad suficiente para alcanzar enemigos dentro de su rango. Al estar sometido a la gravedad, los proyectiles caían al suelo antes de alcanzar los enemigos más lejanos.

He añadido un método que añade una pequeña velocidad vertical al proyectil para que éste pueda alcanzar cualquier enemigo dentro de rango. 
Los proyectiles de catapulta son bastante lentos, así que suelen fallar cuando disparan contra enemigos rápidos o que están muy lejos. Como ahora puede disparar a enemigos lejanos, el ratio de aciertos de la torre de piedra ha empeorado un poco. Recomiendo aumentar la velocidad del proyectil o reducir el rango de la torre para mitigar este efecto (tal vez en la issue #241).